### PR TITLE
eibtalio: BACKEND_UPSTREAM env fürs Frontend (same-origin)

### DIFF
--- a/charts/eibtalio/Chart.yaml
+++ b/charts/eibtalio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: eibtalio
 description: Eibtalio PMS — Hotel Management System for Kinderhotels
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.1.0"
 keywords:
   - eibtalio

--- a/charts/eibtalio/templates/frontend-deployment.yaml
+++ b/charts/eibtalio/templates/frontend-deployment.yaml
@@ -27,6 +27,10 @@ spec:
       containers:
         - name: frontend
           image: {{ .Values.frontend.image }}
+          env:
+            # Backend-Service für den nginx-Proxy (/api,/auth) im Frontend-Image (same-origin).
+            - name: BACKEND_UPSTREAM
+              value: "{{ include "eibtalio.fullname" . }}-backend:{{ .Values.backend.port }}"
           ports:
             - name: http
               containerPort: {{ .Values.frontend.port }}


### PR DESCRIPTION
Setzt im Frontend-Deployment die Env `BACKEND_UPSTREAM` = `<fullname>-backend:<port>`, sodass die nginx im neuen Frontend-Image `/api`,`/auth` same-origin ans Backend proxt. Damit ist das Frontend-Image umgebungsunabhängig (kein `VITE_API_URL`-Baking, kein CORS).

Gehört zu eibtalio-frontend#12. Chart 0.2.0 → 0.3.0 (chart-releaser publiziert; danach Umbrella-Dependency in gitops auf 0.3.0 ziehen).

`helm template`/`helm lint` ok; gleicher fullname-Helper wie der Backend-Service → Env passt immer zum Service-Namen.