### PR TITLE
eibtalio: nächtlicher Testdaten-Reset als CronJob (0.4.0)

### DIFF
--- a/charts/eibtalio/Chart.yaml
+++ b/charts/eibtalio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: eibtalio
 description: Eibtalio PMS — Hotel Management System for Kinderhotels
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.1.0"
 keywords:
   - eibtalio

--- a/charts/eibtalio/templates/testdata-reset-cronjob.yaml
+++ b/charts/eibtalio/templates/testdata-reset-cronjob.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.testdataReset.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "eibtalio.fullname" . }}-testdata-reset
+  labels:
+    {{- include "eibtalio.labels" . | nindent 4 }}
+spec:
+  # Nächtlicher Reset der Testdaten (nur QA/Demo) — erzeugt frische Anreisen/Abreisen für "heute".
+  schedule: {{ .Values.testdataReset.schedule | quote }}
+  timeZone: {{ .Values.testdataReset.timeZone | quote }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            {{- include "eibtalio.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: testdata-reset
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: testdata-reset
+              image: {{ .Values.backend.image }}
+              # Stammdaten/Katalog idempotent sicherstellen, dann Buchungen/Gäste/Zahlungen neu seeden.
+              command: ["sh", "-c", "python -m eibtalio.seed && python -m eibtalio.seed_testdata --reset"]
+              env:
+                - name: EIBTALIO_DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "eibtalio.fullname" . }}-db-app
+                      key: uri
+                - name: EIBTALIO_JWT_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "eibtalio.fullname" . }}-secrets
+                      key: jwt-secret-key
+                - name: EIBTALIO_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "eibtalio.fullname" . }}-secrets
+                      key: admin-password
+                - name: EIBTALIO_DEBUG
+                  value: "true"
+{{- end }}

--- a/charts/eibtalio/values.yaml
+++ b/charts/eibtalio/values.yaml
@@ -42,6 +42,12 @@ postgresql:
   storage:
     size: 5Gi
 
+# Nächtlicher Testdaten-Reset (nur für QA/Demo-Umgebungen aktivieren!)
+testdataReset:
+  enabled: false
+  schedule: "0 2 * * *"
+  timeZone: "Europe/Berlin"
+
 env:
   debug: "false"
   corsOrigins: ""


### PR DESCRIPTION
Optionaler CronJob für QA/Demo-Umgebungen, der die Testdaten nächtlich zurücksetzt.

### Was
- Neues Template `templates/testdata-reset-cronjob.yaml` — gated auf `testdataReset.enabled` (Default **aus**, also in prod-Charts unverändert)
- Läuft `python -m eibtalio.seed && python -m eibtalio.seed_testdata --reset` im Backend-Image: Stammdaten/Katalog idempotent sicherstellen, dann Buchungen/Gäste/Zahlungen neu seeden
- Erzeugt dadurch jede Nacht frische Anreisen/Abreisen für "heute" (offene Check-ins + offene Produkte beim Check-out)
- `concurrencyPolicy: Forbid`, History-Limits, gleiche Secrets wie der init-Job
- Konfigurierbar: `testdataReset.schedule` (Default `0 2 * * *`), `testdataReset.timeZone` (Default `Europe/Berlin`)
- Chart-Version 0.3.0 → **0.4.0**

`helm template` (an/aus) + `helm lint` geprüft. Aktivierung erfolgt per GitOps-Values der QA-Umgebung (separater Commit im gitops-Repo).