### PR TITLE
eibtalio: Migration vor Pod-Rollout bei Upgrades (0.5.0)

### DIFF
--- a/charts/eibtalio/Chart.yaml
+++ b/charts/eibtalio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: eibtalio
 description: Eibtalio PMS — Hotel Management System for Kinderhotels
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "0.1.0"
 keywords:
   - eibtalio

--- a/charts/eibtalio/templates/init-job.yaml
+++ b/charts/eibtalio/templates/init-job.yaml
@@ -5,7 +5,10 @@ metadata:
   labels:
     {{- include "eibtalio.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    # post-install: DB-Cluster existiert erst nach dem Install → danach migrieren+seeden.
+    # pre-upgrade: bei Updates erst migrieren, DANN neue Pods rollen — sonst bedienen neue
+    #   Pods Requests gegen ein noch nicht migriertes Schema (500er-Fenster).
+    helm.sh/hook: post-install,pre-upgrade
     helm.sh/hook-weight: "10"
     helm.sh/hook-delete-policy: before-hook-creation
 spec:


### PR DESCRIPTION
### Problem
Bei Upgrades lief der init-Job (Migration) als `post-upgrade` — also **nachdem** die neuen Pods schon liefen. In dem Fenster (~20s) bedienten die neuen Pods Requests gegen ein noch nicht migriertes Schema → 500er (z.B. `UndefinedColumn` auf neue Spalten).

### Fix
init-Job-Hook `post-install,post-upgrade` → **`post-install,pre-upgrade`**:
- **Install:** weiterhin `post-install` (DB-Cluster existiert erst nach dem Install)
- **Upgrade:** `pre-upgrade` → erst migrieren, dann neue Pods rollen. Schlägt die Migration fehl, bricht der Upgrade ab und die alte Version bedient weiter.

Chart 0.4.0 → 0.5.0. `helm template`/`lint` ok. Aktivierung per gitops-Dependency-Bump (separat).